### PR TITLE
Added indicator for chat message length for issue #5

### DIFF
--- a/web/chat/ChatMessageInput.jsx
+++ b/web/chat/ChatMessageInput.jsx
@@ -5,204 +5,231 @@ import Immutable from 'immutable';
 import Autosuggest from 'react-autosuggest';
 import { sendNewMessage, resetChatInputFocus, setChatInputFocus } from '../redux/actions/chat-actions';
 import { handleCloseAllMenus } from '../redux/actions/menu-actions';
+import { ChatMessageLengthIndicator } from "./ChatMessageLengthIndicator.jsx";
 
 
 const theme = {
-  suggestionsContainer: 'suggestionsContainer',
-  input: 'form-control input-message',
-  suggestion: 'suggestion',
-  suggestionFocused: 'suggestionFocused'
+    suggestionsContainer: 'suggestionsContainer',
+    input: 'form-control input-message',
+    suggestion: 'suggestion',
+    suggestionFocused: 'suggestionFocused'
 };
 
 // HERE BE DRAGONS
 class ChatMessageInput extends Component {
-  constructor(props) {
-    super(props);
-    this.handleKeyPress = this.handleKeyPress.bind(this);
-    this.onChange = this.onChange.bind(this);
-    this.onSuggestionsUpdateRequested = this.onSuggestionsUpdateRequested.bind(this);
-    this.onSuggestionSelected = this.onSuggestionSelected.bind(this);
-    this.getSuggestionValue = this.getSuggestionValue.bind(this);
-    this.getSuggestions = this.getSuggestions.bind(this);
-    this.handleRef = this.handleRef.bind(this);
-    this.state = {
-      value: '',
-      suggestions: this.getSuggestions('')
-    };
-  }
-
-  componentDidMount() {
-    this.props.setChatInputFocus();
-  }
-
-  componentDidUpdate() {
-    const { setInputFocusValue, inputFocusWasSet } = this.props;
-
-    if (!setInputFocusValue) {
-      return false;
-    }
-    this._input.focus();
-    inputFocusWasSet();
-  }
-
-  onChange(event, { newValue }) {
-    return this.setState({
-      value: newValue
-    });
-  }
-
-  onSuggestionsUpdateRequested({ value }) {
-    this.setState({
-      suggestions: this.getSuggestions(value)
-    });
-  }
-
-  onSuggestionSelected(event, { method }) {
-    if (method === 'enter') {
-      // This prevents the handleKeyPress from submitting text
-      //  when selecting an autocomplete
-      event.persist();
-      event.isSuggestionSelected = true; // eslint-disable-line
-    }
-  }
-
-  getSuggestionValue(suggestion) {
-    // When a suggestion is selected, we want to fill in
-    // the suggestion in the rest of the input text.
-    // Note: We assume the suggestion is always at the end.
-    const lastInputTokens = this.state.value.trim().split(' ');
-    const lastToken = lastInputTokens.pop();
-    const lastTokenIsMention = lastToken.length !== 0 && lastToken[0] === '@';
-
-    if (lastTokenIsMention) {
-      const inputWithoutLastToken = lastInputTokens.join(' ');
-      const inputWithAtTrimmed = `${inputWithoutLastToken} @`.trim();
-      return `${inputWithAtTrimmed}${suggestion} `;
-    }
-    return suggestion;
-  }
-
-  getSuggestions(value) {
-    const { members } = this.props;
-    const lastInputToken = value.toLowerCase().split(' ').pop();
-    const userIsAttemptingMention = lastInputToken[0] === '@' && lastInputToken.length > 1;
-    if (!userIsAttemptingMention) {
-      return [];
+    constructor(props) {
+        super(props);
+        this.handleKeyPress = this.handleKeyPress.bind(this);
+        this.onChange = this.onChange.bind(this);
+        this.onSuggestionsUpdateRequested = this.onSuggestionsUpdateRequested.bind(this);
+        this.onSuggestionSelected = this.onSuggestionSelected.bind(this);
+        this.getSuggestionValue = this.getSuggestionValue.bind(this);
+        this.getSuggestions = this.getSuggestions.bind(this);
+        this.handleRef = this.handleRef.bind(this);
+        this.state = {
+            value: '',
+            indicatorProps: {
+                max: 500, //Change if part of the store,
+                visibleAt: 100,
+                highlightAt: 50
+            },
+            suggestions: this.getSuggestions('')
+        };
     }
 
-    const queryWithoutAt = lastInputToken.slice(1, lastInputToken.length);
-    return members.filter(member => {
-      return member.toLowerCase().slice(0, lastInputToken.length - 1) === queryWithoutAt;
-    }).toJS();
-  }
-
-  handleKeyPress(event) {
-    const { roomName, onSendNewMessage, onMessageInput } = this.props;
-
-    if (event.key === 'Enter' && !event.isSuggestionSelected) {
-      event.preventDefault();
-      onSendNewMessage(roomName, event.target.value);
-      this.setState({
-        value: ''
-      });
-
-      onMessageInput();
-    }
-  }
-
-  handleRef(ref) {
-    this._input = ref;
-  }
-
-  renderSuggestion(suggestion) {
-    return (
-        <span>{suggestion}</span>
-    );
-  }
-
-  renderPlaceholder(props) {
-    const { connected, roomName } = this.props;
-
-    if (!connected) {
-      return 'Disconnected from server';
+    componentDidMount() {
+        this.props.setChatInputFocus();
     }
 
-    return `Type a message to #${roomName}...`;
-  }
+    componentDidUpdate() {
+        const { setInputFocusValue, inputFocusWasSet } = this.props;
 
-  render() {
-    const { value, suggestions } = this.state;
-    const { connected, closeSidebar } = this.props;
+        if (!setInputFocusValue) {
+            return false;
+        }
+        this._input.focus();
+        inputFocusWasSet();
+    }
 
-    const inputProps = {
-      placeholder: this.renderPlaceholder(),
-      value,
-      onChange: this.onChange,
-      onKeyDown: this.handleKeyPress,
-      onFocus: closeSidebar,
-      disabled: !connected,
-      ref: this.handleRef
-    };
+    onChange(event, { newValue }) {
+        return this.setState({
+            value: newValue
+        });
+    }
 
-    return (
-      <Autosuggest suggestions={suggestions}
-                   onSuggestionsUpdateRequested={this.onSuggestionsUpdateRequested}
-                   getSuggestionValue={this.getSuggestionValue}
-                   onSuggestionSelected={this.onSuggestionSelected}
-                   renderSuggestion={this.renderSuggestion}
-                   inputProps={inputProps}
-                   theme={theme}
-                   tabToSelect
-                   selectFirstSuggestion
-      />
-    );
-  }
+    onSuggestionsUpdateRequested({ value }) {
+        this.setState({
+            suggestions: this.getSuggestions(value)
+        });
+    }
+
+    onSuggestionSelected(event, { method }) {
+        if (method === 'enter') {
+            // This prevents the handleKeyPress from submitting text
+            //  when selecting an autocomplete
+            event.persist();
+            event.isSuggestionSelected = true; // eslint-disable-line
+        }
+    }
+
+    getSuggestionValue(suggestion) {
+        // When a suggestion is selected, we want to fill in
+        // the suggestion in the rest of the input text.
+        // Note: We assume the suggestion is always at the end.
+        const lastInputTokens = this.state.value.trim().split(' ');
+        const lastToken = lastInputTokens.pop();
+        const lastTokenIsMention = lastToken.length !== 0 && lastToken[0] === '@';
+
+        if (lastTokenIsMention) {
+            const inputWithoutLastToken = lastInputTokens.join(' ');
+            const inputWithAtTrimmed = `${inputWithoutLastToken} @`.trim();
+            return `${inputWithAtTrimmed}${suggestion} `;
+        }
+        return suggestion;
+    }
+
+    getSuggestions(value) {
+        const { members } = this.props;
+        const lastInputToken = value.toLowerCase().split(' ').pop();
+        const userIsAttemptingMention = lastInputToken[0] === '@' && lastInputToken.length > 1;
+        if (!userIsAttemptingMention) {
+            return [];
+        }
+
+        const queryWithoutAt = lastInputToken.slice(1, lastInputToken.length);
+        return members.filter(member => {
+            return member.toLowerCase().slice(0, lastInputToken.length - 1) === queryWithoutAt;
+        }).toJS();
+    }
+
+    handleKeyPress(event) {
+        const { roomName, onSendNewMessage, onMessageInput } = this.props;
+
+        if (event.key === 'Enter' && !event.isSuggestionSelected) {
+            event.preventDefault();
+            onSendNewMessage(roomName, event.target.value);
+            this.setState({
+                value: ''
+            });
+
+            onMessageInput();
+        }
+    }
+
+    handleRef(ref) {
+        this._input = ref;
+    }
+
+    getIndicator(indicatorProps, length) {
+        let indicator = undefined;
+        if (indicatorProps.max - length < indicatorProps.visibleAt) {
+            indicator = <ChatMessageLengthIndicator max={indicatorProps.max}
+                                                    length={length}
+                                                    highlightAt={indicatorProps.highlightAt}/>
+        }
+
+        return indicator;
+    }
+
+    renderSuggestion(suggestion) {
+        return (
+            <span>{suggestion}</span>
+        );
+    }
+
+    renderPlaceholder(props) {
+        const { connected, roomName } = this.props;
+
+        if (!connected) {
+            return 'Disconnected from server';
+        }
+
+        return `Type a message to #${roomName}...`;
+    }
+
+    render() {
+        const { value, suggestions, indicatorProps } = this.state;
+        const { connected, closeSidebar } = this.props;
+
+        const inputProps = {
+            placeholder: this.renderPlaceholder(),
+            value,
+            onChange: this.onChange,
+            onKeyDown: this.handleKeyPress,
+            onFocus: closeSidebar,
+            disabled: !connected,
+            ref: this.handleRef
+        };
+
+        const indicator = this.getIndicator(indicatorProps, value.length);
+        const divClasses = (indicator) ? "input-group": "";
+
+        return (
+            <div className={divClasses}>
+                <Autosuggest suggestions={suggestions}
+                             onSuggestionsUpdateRequested={this.onSuggestionsUpdateRequested}
+                             getSuggestionValue={this.getSuggestionValue}
+                             onSuggestionSelected={this.onSuggestionSelected}
+                             renderSuggestion={this.renderSuggestion}
+                             inputProps={inputProps}
+                             theme={theme}
+                             tabToSelect
+                             selectFirstSuggestion
+                />
+                {indicator}
+            </div>
+        );
+    }
 }
 
 ChatMessageInput.defaultProps = {
-  roomName: '',
-  members: Immutable.Map(),
-  connected: true,
-  setInputFocusValue: false,
-  closeSidebar: () => {},
-  inputFocusWasSet: () => {},
-  setChatInputFocus: () => {},
-  onSendNewMessage: () => {}
+    roomName: '',
+    members: Immutable.Map(),
+    connected: true,
+    setInputFocusValue: false,
+    closeSidebar: () => {
+    },
+    inputFocusWasSet: () => {
+    },
+    setChatInputFocus: () => {
+    },
+    onSendNewMessage: () => {
+    }
 };
 
 function mapStateToProps(state) {
-  const roomName = state.get('currentRoom');
-  const membersMap = state.getIn(['members', roomName], Immutable.Map());
-  const members = membersMap.reduce((a, b) => a.union(b), Immutable.OrderedSet()).toList();
-  const connected = state.getIn(['ui', 'connected']);
-  const setInputFocusValue = state.getIn(['ui', 'setInputFocus'], false);
+    const roomName = state.get('currentRoom');
+    const membersMap = state.getIn(['members', roomName], Immutable.Map());
+    const members = membersMap.reduce((a, b) => a.union(b), Immutable.OrderedSet()).toList();
+    const connected = state.getIn(['ui', 'connected']);
+    const setInputFocusValue = state.getIn(['ui', 'setInputFocus'], false);
 
-  return {
-    members,
-    roomName,
-    connected,
-    setInputFocusValue
-  };
+    return {
+        members,
+        roomName,
+        connected,
+        setInputFocusValue
+    };
 }
 
 function mapDispatchToProps(dispatch) {
-  return {
-    closeSidebar() {
-      dispatch(handleCloseAllMenus());
-    },
-    inputFocusWasSet() {
-      dispatch(resetChatInputFocus());
-    },
-    setChatInputFocus() {
-      dispatch(setChatInputFocus());
-    },
-    onSendNewMessage(roomName, message) {
-      dispatch(sendNewMessage({
-        message,
-        roomName
-      }));
-    }
-  };
+    return {
+        closeSidebar() {
+            dispatch(handleCloseAllMenus());
+        },
+        inputFocusWasSet() {
+            dispatch(resetChatInputFocus());
+        },
+        setChatInputFocus() {
+            dispatch(setChatInputFocus());
+        },
+        onSendNewMessage(roomName, message) {
+            dispatch(sendNewMessage({
+                message,
+                roomName
+            }));
+        }
+    };
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(ChatMessageInput)

--- a/web/chat/ChatMessageLengthIndicator.jsx
+++ b/web/chat/ChatMessageLengthIndicator.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export const ChatMessageLengthIndicator = (props) => {
+
+    const classNames = ["input-group-addon",
+        ((props.max - props.length < props.highlightAt) ? 'btn-danger' : '')]
+        .join(" ");
+
+    return (
+        <div className={classNames}>
+            {props.max - props.length}
+        </div>
+    );
+}

--- a/web/chat/ChatMessageLengthIndicator.jsx
+++ b/web/chat/ChatMessageLengthIndicator.jsx
@@ -1,14 +1,13 @@
-import React from "react";
+import React from 'react';
 
 export const ChatMessageLengthIndicator = (props) => {
+  const classNames = ['input-group-addon',
+    ((props.max - props.length < props.highlightAt) ? 'btn-danger' : '')]
+    .join(' ');
 
-    const classNames = ["input-group-addon",
-        ((props.max - props.length < props.highlightAt) ? 'btn-danger' : '')]
-        .join(" ");
-
-    return (
-        <div className={classNames}>
-            {props.max - props.length}
-        </div>
-    );
-}
+  return (
+    <div className={classNames}>
+      {props.max - props.length}
+    </div>
+  );
+};


### PR DESCRIPTION
## Pull request for issue #5 

I added an indicator for the length of a message. The indicator is hidden until the message hits 100 remaining characters. At 50 remaining it gets highlighted.

The numbers can be changed in the constructor (initial state). For styling I stayed within bootstrap, if the indicator is visible I change the input field into an "input-group" and add an "input-group-addon" (http://getbootstrap.com/css/#forms-inline). Because of the default formatting of "input-group" I had to add some conditions which makes the code "uglier" than I hoped. 

Besides ChatMessageLengthIndicator.jsx the relevant lines in ChatMessageInput.jsx are

- 31-35 - initial state of Indicator
- 123-129 - Indicator creation
- 164-180 - render function

### Visuals
![input](https://cloud.githubusercontent.com/assets/6655009/15778923/84b5bda8-2999-11e6-98a0-f128e20344f5.PNG)
![input2](https://cloud.githubusercontent.com/assets/6655009/15778927/896eddb6-2999-11e6-871b-23394fabead1.PNG)
![input3](https://cloud.githubusercontent.com/assets/6655009/15778929/8d16ed1e-2999-11e6-83a1-812661865f01.PNG)

If you don't like the additional div's in the render method I could write a container class, if the state should be in redux (since it is local state I believe it shouldn't be), if changing the css instead of adding if's to the code is preferable or if anything else is "wrong" - let me know.
