### PR TITLE
Active rooms list

### DIFF
--- a/app/com/larvalabs/redditchat/dataobj/JsonActiveChatRoom.java
+++ b/app/com/larvalabs/redditchat/dataobj/JsonActiveChatRoom.java
@@ -1,0 +1,22 @@
+package com.larvalabs.redditchat.dataobj;
+
+import java.io.Serializable;
+
+public final class JsonActiveChatRoom implements Serializable{
+    private final String roomName;
+    private final int activeUsers;
+
+    public JsonActiveChatRoom(String roomName, int activeUsers) {
+        this.roomName = roomName;
+        this.activeUsers = activeUsers;
+    }
+
+    public String getRoomName() {
+        return roomName;
+    }
+
+    public int getActiveUsers() {
+        return activeUsers;
+    }
+
+}

--- a/app/com/larvalabs/redditchat/dataobj/JsonActiveChatRoom.java
+++ b/app/com/larvalabs/redditchat/dataobj/JsonActiveChatRoom.java
@@ -3,17 +3,25 @@ package com.larvalabs.redditchat.dataobj;
 import java.io.Serializable;
 
 public final class JsonActiveChatRoom implements Serializable{
-    private final String roomName;
+    private final String name;
+    private final String displayName;
+    private final String iconUrl;
     private final int activeUsers;
 
-    public JsonActiveChatRoom(String roomName, int activeUsers) {
-        this.roomName = roomName;
+    public JsonActiveChatRoom(String roomName, String displayName, String iconUrl, int activeUsers) {
+        this.name = roomName;
+        this.displayName = displayName;
+        this.iconUrl = iconUrl;
         this.activeUsers = activeUsers;
     }
 
-    public String getRoomName() {
-        return roomName;
+    public String getName() {
+        return name;
     }
+
+    public String getDisplayName() { return displayName; }
+
+    public String getIconUrl() { return iconUrl; }
 
     public int getActiveUsers() {
         return activeUsers;

--- a/app/com/larvalabs/redditchat/dataobj/JsonActiveChatRoom.java
+++ b/app/com/larvalabs/redditchat/dataobj/JsonActiveChatRoom.java
@@ -3,17 +3,25 @@ package com.larvalabs.redditchat.dataobj;
 import java.io.Serializable;
 
 public final class JsonActiveChatRoom implements Serializable{
+    private final int id;
+    private final int rank;
     private final String name;
     private final String displayName;
     private final String iconUrl;
     private final int activeUsers;
 
-    public JsonActiveChatRoom(String roomName, String displayName, String iconUrl, int activeUsers) {
+    public JsonActiveChatRoom(int id, String roomName, String displayName, String iconUrl, int activeUsers, int rank) {
+        this.id = id;
         this.name = roomName;
         this.displayName = displayName;
         this.iconUrl = iconUrl;
         this.activeUsers = activeUsers;
+        this.rank = rank;
     }
+
+    public int getId() { return id; }
+
+    public int getRank() { return rank; }
 
     public String getName() {
         return name;

--- a/app/com/larvalabs/redditchat/dataobj/JsonActiveRoomsUtil.java
+++ b/app/com/larvalabs/redditchat/dataobj/JsonActiveRoomsUtil.java
@@ -12,15 +12,18 @@ public class JsonActiveRoomsUtil {
         HashMap<String, JsonActiveChatRoom> activeRoomsState = new HashMap<>();
         List<ChatUserRoomJoin> joinedUserRoom = JoinedRoomsService.findJoinedRooms(user);
 
-        List<JsonActiveChatRoom> activeRoomsList = ActiveRoomsService.getActiveRooms(); // load top 30
+        List<JsonActiveChatRoom> activeRoomsList = new ArrayList<>();
 
-        activeRoomsState = updateRoomsToState(activeRoomsState, activeRoomsList, joinedUserRoom, offset, amount);
-        offset = getLastRank(offset, activeRoomsList);
+        if (offset < 30) {
+            activeRoomsList = ActiveRoomsService.getActiveRooms(); // load top 30
+            activeRoomsState = updateRoomsToState(activeRoomsState, activeRoomsList, joinedUserRoom, offset, amount);
+            offset = getLastRank(offset, activeRoomsList);
+        }
 
         List<JsonActiveChatRoom> additionalRooms = new ArrayList<>();
 
-        while(activeRoomsState.size() < amount &&
-                (additionalRooms = ActiveRoomsService.findMostActiveRooms(amount-activeRoomsState.size(), offset, user.getId())).size() > 0) {
+        while (activeRoomsState.size() < amount &&
+                (additionalRooms = ActiveRoomsService.findMostActiveRooms(amount - activeRoomsState.size(), offset-1, user.getId())).size() > 0) {
 
             activeRoomsState = updateRoomsToState(activeRoomsState, additionalRooms, joinedUserRoom, offset, amount);
             offset = getLastRank(offset, additionalRooms);
@@ -37,10 +40,10 @@ public class JsonActiveRoomsUtil {
             }
         });
 
-        for(JsonActiveChatRoom room : rooms) {
-            if(room.getRank() > offset && !state.containsKey(room.getName()) && !isJoinedRoom(joinedUserRoom, room)){
+        for (JsonActiveChatRoom room : rooms) {
+            if (room.getRank() > offset && !state.containsKey(room.getName()) && !isJoinedRoom(joinedUserRoom, room)) {
                 state.put(room.getName(), room);
-                if(state.size() >= amount) return state;
+                if (state.size() >= amount) return state;
             }
         }
 
@@ -48,16 +51,18 @@ public class JsonActiveRoomsUtil {
     }
 
     private static int getLastRank(int offset, List<JsonActiveChatRoom> list) {
-        for(JsonActiveChatRoom room : list) {
-            if(offset < room.getRank()) { offset = room.getRank(); }
+        for (JsonActiveChatRoom room : list) {
+            if (offset < room.getRank()) {
+                offset = room.getRank();
+            }
         }
 
         return offset;
     }
 
     private static boolean isJoinedRoom(List<ChatUserRoomJoin> joinedUserRoom, JsonActiveChatRoom room) {
-        for(ChatUserRoomJoin joinedRoom : joinedUserRoom) {
-            if(joinedRoom.getRoom().getName().equals(room.getName())) {
+        for (ChatUserRoomJoin joinedRoom : joinedUserRoom) {
+            if (joinedRoom.getRoom().getName().equals(room.getName())) {
                 return true;
             }
         }

--- a/app/com/larvalabs/redditchat/dataobj/JsonActiveRoomsUtil.java
+++ b/app/com/larvalabs/redditchat/dataobj/JsonActiveRoomsUtil.java
@@ -1,0 +1,53 @@
+package com.larvalabs.redditchat.dataobj;
+
+import com.larvalabs.redditchat.services.ActiveRoomsService;
+
+import java.util.*;
+
+public class JsonActiveRoomsUtil {
+    public static HashMap<String, JsonActiveChatRoom> getActiveRooms(Long userId) {
+        HashMap<String, JsonActiveChatRoom> activeRoomsState = new HashMap<>();
+        List<JsonActiveChatRoom> activeRoomsList = ActiveRoomsService.getActiveRooms();
+
+        activeRoomsState = updateRoomsToState(activeRoomsState, activeRoomsList);
+        int offset = getLastRank(0, activeRoomsList);
+
+        List<JsonActiveChatRoom> additionalRooms = new ArrayList<>();
+
+        while(activeRoomsState.size() < 5 &&
+                (additionalRooms = ActiveRoomsService.findMostActiveRooms(5-activeRoomsList.size(), offset, userId)).size() > 0) {
+
+            activeRoomsState = updateRoomsToState(activeRoomsState, additionalRooms);
+            offset = getLastRank(offset, additionalRooms);
+        }
+
+        return activeRoomsState;
+    }
+
+    private static HashMap<String, JsonActiveChatRoom> updateRoomsToState(HashMap<String, JsonActiveChatRoom> state, List<JsonActiveChatRoom> rooms) {
+        Collections.sort(rooms, new Comparator<JsonActiveChatRoom>() {
+            @Override
+            public int compare(JsonActiveChatRoom room1, JsonActiveChatRoom room2) {
+                return room1.getRank() - room2.getRank();
+            }
+        });
+
+
+        for(JsonActiveChatRoom room : rooms) {
+            if(!state.containsKey(room.getName())){
+                state.put(room.getName(), room);
+                if(state.size() >= 5) return state;
+            }
+        }
+
+        return state;
+    }
+
+    private static int getLastRank(int offset, List<JsonActiveChatRoom> list) {
+        for(JsonActiveChatRoom room : list) {
+            if(offset < room.getRank()) { offset = room.getRank(); }
+        }
+
+        return offset;
+    }
+}

--- a/app/com/larvalabs/redditchat/dataobj/JsonUtil.java
+++ b/app/com/larvalabs/redditchat/dataobj/JsonUtil.java
@@ -110,9 +110,11 @@ public class JsonUtil {
             }
         }
 
-        List<JsonActiveChatRoom> activeRooms = ActiveRoomsService.getInstance().findMostActiveRooms(5, 0);
-        for(int i = 0; i < activeRooms.size(); i++) {
-            state.activeRooms.put(i+1, activeRooms.get(i));
+        /* Active rooms are also displayed for anonymous users */
+        Long userId = (user != null) ? user.getId() : null;
+        List<JsonActiveChatRoom> activeRooms = ActiveRoomsService.getInstance().findMostActiveRooms(5, 0, userId);
+        for(JsonActiveChatRoom room : activeRooms) {
+            state.activeRooms.put(room.getRank(), room);
         }
 
         Stats.measure(Stats.StatKey.LOAD_FULLSTATE_TIME, (System.currentTimeMillis() - startTime));

--- a/app/com/larvalabs/redditchat/dataobj/JsonUtil.java
+++ b/app/com/larvalabs/redditchat/dataobj/JsonUtil.java
@@ -1,5 +1,6 @@
 package com.larvalabs.redditchat.dataobj;
 
+import com.larvalabs.redditchat.services.ActiveRoomsService;
 import com.larvalabs.redditchat.util.RedisUtil;
 import com.larvalabs.redditchat.util.Stats;
 import models.ChatRoom;
@@ -43,6 +44,7 @@ public class JsonUtil {
 
 
         public TreeMap<String, JsonChatRoom> rooms = new TreeMap<>(lowerStringComparator);
+        public HashMap<Integer, JsonActiveChatRoom> activeRooms = new HashMap<>();
         public TreeMap<String, JsonUser> users = new TreeMap<>(lowerStringComparator);
         public TreeMap<String, JsonRoomMembers> members = new TreeMap<>(lowerStringComparator);
         public TreeMap<String, ArrayList<String>> roomMessages = new TreeMap<>(lowerStringComparator);
@@ -106,6 +108,11 @@ public class JsonUtil {
             if (user.equals(thisUser)) {
                 state.lastSeenTimes.put(roomName, chatRoomJoin.getLastSeenMessageTime());
             }
+        }
+
+        List<JsonActiveChatRoom> activeRooms = ActiveRoomsService.getInstance().findMostActiveRooms(5, 0);
+        for(int i = 0; i < activeRooms.size(); i++) {
+            state.activeRooms.put(i+1, activeRooms.get(i));
         }
 
         Stats.measure(Stats.StatKey.LOAD_FULLSTATE_TIME, (System.currentTimeMillis() - startTime));

--- a/app/com/larvalabs/redditchat/dataobj/JsonUtil.java
+++ b/app/com/larvalabs/redditchat/dataobj/JsonUtil.java
@@ -6,7 +6,6 @@ import com.larvalabs.redditchat.util.Stats;
 import models.ChatRoom;
 import models.ChatUser;
 import models.ChatUserRoomJoin;
-import play.Logger;
 import play.db.jpa.JPA;
 
 import javax.persistence.Query;
@@ -112,13 +111,13 @@ public class JsonUtil {
 
         /* Active rooms are also displayed for anonymous users */
         Long userId = (user != null) ? user.getId() : null;
-        List<JsonActiveChatRoom> activeRooms = ActiveRoomsService.getInstance().findMostActiveRooms(5, 0, userId);
-        for(JsonActiveChatRoom room : activeRooms) {
-            state.activeRooms.put(room.getName(), room);
-        }
+
+        state.activeRooms = JsonActiveRoomsUtil.getActiveRooms(userId);
 
         Stats.measure(Stats.StatKey.LOAD_FULLSTATE_TIME, (System.currentTimeMillis() - startTime));
 
         return state;
     }
+
+
 }

--- a/app/com/larvalabs/redditchat/dataobj/JsonUtil.java
+++ b/app/com/larvalabs/redditchat/dataobj/JsonUtil.java
@@ -1,6 +1,7 @@
 package com.larvalabs.redditchat.dataobj;
 
 import com.larvalabs.redditchat.services.ActiveRoomsService;
+import com.larvalabs.redditchat.services.JoinedRoomsService;
 import com.larvalabs.redditchat.util.RedisUtil;
 import com.larvalabs.redditchat.util.Stats;
 import models.ChatRoom;
@@ -53,11 +54,7 @@ public class JsonUtil {
         long startTime = System.currentTimeMillis();
         FullState state = new FullState();
 
-        Query getAllStuffQuery = JPA.em().createQuery("select ur from ChatUserRoomJoin ur join fetch ur.room urr join fetch ur.user u where ur.room " +
-                "in (select room from ChatUserRoomJoin ur2 where ur2.user = :user) " +
-                "and ur.room.deleted = false and ur.room.open = true")
-                .setParameter("user", user);
-        List<ChatUserRoomJoin> resultList = getAllStuffQuery.getResultList();
+        List<ChatUserRoomJoin> resultList = JoinedRoomsService.findJoinedRooms(user);
 
         TreeSet<String> usernamesPresent = RedisUtil.getAllOnlineUsersForAllRooms();
         usernamesPresent.add(user.getUsername());   // Make sure user we're preloading it marked as online

--- a/app/com/larvalabs/redditchat/dataobj/JsonUtil.java
+++ b/app/com/larvalabs/redditchat/dataobj/JsonUtil.java
@@ -40,8 +40,6 @@ public class JsonUtil {
             }
         };
 
-
-
         public TreeMap<String, JsonChatRoom> rooms = new TreeMap<>(lowerStringComparator);
         public HashMap<String, JsonActiveChatRoom> activeRooms = new HashMap<>();
         public TreeMap<String, JsonUser> users = new TreeMap<>(lowerStringComparator);
@@ -112,9 +110,7 @@ public class JsonUtil {
         }
 
         /* Active rooms are also displayed for anonymous users */
-        Long userId = (user != null) ? user.getId() : null;
-
-        state.activeRooms = JsonActiveRoomsUtil.getActiveRooms(userId);
+        state.activeRooms = JsonActiveRoomsUtil.getActiveRooms(user, 0, 5);
 
         Stats.measure(Stats.StatKey.LOAD_FULLSTATE_TIME, (System.currentTimeMillis() - startTime));
 

--- a/app/com/larvalabs/redditchat/dataobj/JsonUtil.java
+++ b/app/com/larvalabs/redditchat/dataobj/JsonUtil.java
@@ -44,7 +44,7 @@ public class JsonUtil {
 
 
         public TreeMap<String, JsonChatRoom> rooms = new TreeMap<>(lowerStringComparator);
-        public HashMap<Integer, JsonActiveChatRoom> activeRooms = new HashMap<>();
+        public HashMap<String, JsonActiveChatRoom> activeRooms = new HashMap<>();
         public TreeMap<String, JsonUser> users = new TreeMap<>(lowerStringComparator);
         public TreeMap<String, JsonRoomMembers> members = new TreeMap<>(lowerStringComparator);
         public TreeMap<String, ArrayList<String>> roomMessages = new TreeMap<>(lowerStringComparator);
@@ -114,7 +114,7 @@ public class JsonUtil {
         Long userId = (user != null) ? user.getId() : null;
         List<JsonActiveChatRoom> activeRooms = ActiveRoomsService.getInstance().findMostActiveRooms(5, 0, userId);
         for(JsonActiveChatRoom room : activeRooms) {
-            state.activeRooms.put(room.getRank(), room);
+            state.activeRooms.put(room.getName(), room);
         }
 
         Stats.measure(Stats.StatKey.LOAD_FULLSTATE_TIME, (System.currentTimeMillis() - startTime));

--- a/app/com/larvalabs/redditchat/services/ActiveRoomsService.java
+++ b/app/com/larvalabs/redditchat/services/ActiveRoomsService.java
@@ -1,0 +1,50 @@
+package com.larvalabs.redditchat.services;
+
+import com.larvalabs.redditchat.dataobj.JsonActiveChatRoom;
+import play.db.jpa.JPA;
+
+import javax.persistence.Query;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class ActiveRoomsService {
+    private static ActiveRoomsService instance = null;
+
+    protected ActiveRoomsService() {}
+
+    public static ActiveRoomsService getInstance() {
+        if(instance == null) {
+            instance = new ActiveRoomsService();
+        }
+        return instance;
+    }
+
+    public List<JsonActiveChatRoom> findMostActiveRooms(int limit, int offset) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("SELECT cr.displayname AS roomName, COUNT(DISTINCT user_id) AS activeUsers FROM chatroom cr ");
+        sb.append("LEFT JOIN message m on cr.id = m.room_id ");
+        sb.append("WHERE m.createdate > (current_timestamp - interval '30 days') ");
+        sb.append("GROUP BY cr.displayname ");
+        sb.append("ORDER BY activeUsers desc ");
+        sb.append("LIMIT :limit ");
+        sb.append("OFFSET :offset");
+
+        Query activeRoomsQuery = JPA.em().createNativeQuery(sb.toString());
+        activeRoomsQuery.setParameter("limit", limit);
+        activeRoomsQuery.setParameter("offset", offset);
+
+        return convert(activeRoomsQuery.getResultList());
+    }
+
+    private List<JsonActiveChatRoom> convert(List<Object[]> activeRoomsObjects) {
+        List<JsonActiveChatRoom> activeRooms = new ArrayList<>();
+        for(Object[] room : activeRoomsObjects) {
+            System.out.println("room: "+room.toString());
+            activeRooms.add(new JsonActiveChatRoom(room[0].toString(), Integer.parseInt(room[1].toString())));
+        }
+
+        return activeRooms;
+    }
+}

--- a/app/com/larvalabs/redditchat/services/ActiveRoomsService.java
+++ b/app/com/larvalabs/redditchat/services/ActiveRoomsService.java
@@ -23,25 +23,6 @@ public class ActiveRoomsService {
     public List<JsonActiveChatRoom> findMostActiveRooms(int limit, int offset, Long userId) {
         StringBuilder sb = new StringBuilder();
 
-        /*
-            SELECT id, name, displayName, iconUrl, activeUsers, rank
-            FROM (
-                SELECT cr.id AS id, cr.name AS name, cr.displayname AS displayName, cr.iconurl AS iconUrl, COUNT(DISTINCT user_id) AS activeUsers, RANK() OVER (ORDER BY COUNT(DISTINCT user_id) DESC, name) as rank
-                FROM chatroom cr
-                LEFT JOIN message m on cr.id = m.room_id
-                WHERE m.createdate > (current_timestamp - interval '30 days')
-                GROUP BY cr.id, cr.name, cr.displayname, cr.iconurl
-                ORDER BY activeUsers DESC
-            ) AS ranked
-            WHERE name <> 'breakerapp' AND id NOT IN (
-                SELECT room_id
-                FROM userroom
-                WHERE user_id = 35
-            )
-            LIMIT 5
-            OFFSET 0;
-         */
-
         sb.append("SELECT id, name, displayName, iconUrl, activeUsers, rank ")
           .append("FROM ( ")
             .append("SELECT cr.id AS id, cr.name AS name, cr.displayname AS displayName, cr.iconurl AS iconUrl, COUNT(DISTINCT user_id) AS activeUsers, RANK() OVER (ORDER BY COUNT(DISTINCT user_id) DESC, name) as rank ")

--- a/app/com/larvalabs/redditchat/services/ActiveRoomsService.java
+++ b/app/com/larvalabs/redditchat/services/ActiveRoomsService.java
@@ -42,9 +42,9 @@ public class ActiveRoomsService {
           .append(") AS ranked ")
           .append("WHERE name <> 'breakerapp' AND id NOT IN ( ")
             .append("SELECT room_id ")
-            .append("FROM userroom ");
-          sb.append("WHERE user_id = :userId ");
-          sb.append(") ")
+            .append("FROM userroom ")
+            .append("WHERE user_id = :userId ")
+            .append(") ")
           .append("LIMIT :limit ")
           .append("OFFSET :offset");
 

--- a/app/com/larvalabs/redditchat/services/ActiveRoomsService.java
+++ b/app/com/larvalabs/redditchat/services/ActiveRoomsService.java
@@ -23,10 +23,10 @@ public class ActiveRoomsService {
     public List<JsonActiveChatRoom> findMostActiveRooms(int limit, int offset) {
         StringBuilder sb = new StringBuilder();
 
-        sb.append("SELECT cr.displayname AS roomName, COUNT(DISTINCT user_id) AS activeUsers FROM chatroom cr ");
+        sb.append("SELECT cr.name AS name, cr.displayname AS displayName, cr.iconurl AS iconUrl, COUNT(DISTINCT user_id) AS activeUsers FROM chatroom cr ");
         sb.append("LEFT JOIN message m on cr.id = m.room_id ");
         sb.append("WHERE m.createdate > (current_timestamp - interval '30 days') ");
-        sb.append("GROUP BY cr.displayname ");
+        sb.append("GROUP BY cr.name, cr.displayname, cr.iconurl ");
         sb.append("ORDER BY activeUsers desc ");
         sb.append("LIMIT :limit ");
         sb.append("OFFSET :offset");
@@ -41,8 +41,7 @@ public class ActiveRoomsService {
     private List<JsonActiveChatRoom> convert(List<Object[]> activeRoomsObjects) {
         List<JsonActiveChatRoom> activeRooms = new ArrayList<>();
         for(Object[] room : activeRoomsObjects) {
-            System.out.println("room: "+room.toString());
-            activeRooms.add(new JsonActiveChatRoom(room[0].toString(), Integer.parseInt(room[1].toString())));
+            activeRooms.add(new JsonActiveChatRoom(room[0].toString(), room[1].toString(), (room[2] != null) ? room[2].toString() : "", Integer.parseInt(room[3].toString())));
         }
 
         return activeRooms;

--- a/app/com/larvalabs/redditchat/services/ActiveRoomsService.java
+++ b/app/com/larvalabs/redditchat/services/ActiveRoomsService.java
@@ -43,7 +43,6 @@ public class ActiveRoomsService {
           .append("WHERE name <> 'breakerapp' AND id NOT IN ( ")
             .append("SELECT room_id ")
             .append("FROM userroom ");
-        if(userId != null)
           sb.append("WHERE user_id = :userId ");
           sb.append(") ")
           .append("LIMIT :limit ")
@@ -51,8 +50,10 @@ public class ActiveRoomsService {
 
         Query activeRoomsQuery = JPA.em().createNativeQuery(sb.toString());
         activeRoomsQuery.setParameter("limit", limit);
+        offset = (offset != 0) ? offset-1 : offset;
         activeRoomsQuery.setParameter("offset", offset);
-        if(userId != null) activeRoomsQuery.setParameter("userId", userId);
+        userId = (userId != null) ? userId : -1;
+        activeRoomsQuery.setParameter("userId", userId);
 
         return convert(activeRoomsQuery.getResultList());
     }

--- a/app/com/larvalabs/redditchat/services/ActiveRoomsService.java
+++ b/app/com/larvalabs/redditchat/services/ActiveRoomsService.java
@@ -20,20 +20,50 @@ public class ActiveRoomsService {
         return instance;
     }
 
-    public List<JsonActiveChatRoom> findMostActiveRooms(int limit, int offset) {
+    public List<JsonActiveChatRoom> findMostActiveRooms(int limit, int offset, Long userId) {
         StringBuilder sb = new StringBuilder();
 
-        sb.append("SELECT cr.name AS name, cr.displayname AS displayName, cr.iconurl AS iconUrl, COUNT(DISTINCT user_id) AS activeUsers FROM chatroom cr ");
-        sb.append("LEFT JOIN message m on cr.id = m.room_id ");
-        sb.append("WHERE m.createdate > (current_timestamp - interval '30 days') ");
-        sb.append("GROUP BY cr.name, cr.displayname, cr.iconurl ");
-        sb.append("ORDER BY activeUsers desc ");
-        sb.append("LIMIT :limit ");
-        sb.append("OFFSET :offset");
+        /*
+            SELECT id, name, displayName, iconUrl, activeUsers, rank
+            FROM (
+                SELECT cr.id AS id, cr.name AS name, cr.displayname AS displayName, cr.iconurl AS iconUrl, COUNT(DISTINCT user_id) AS activeUsers, RANK() OVER (ORDER BY COUNT(DISTINCT user_id) DESC, name) as rank
+                FROM chatroom cr
+                LEFT JOIN message m on cr.id = m.room_id
+                WHERE m.createdate > (current_timestamp - interval '30 days')
+                GROUP BY cr.id, cr.name, cr.displayname, cr.iconurl
+                ORDER BY activeUsers DESC
+            ) AS ranked
+            WHERE name <> 'breakerapp' AND id NOT IN (
+                SELECT room_id
+                FROM userroom
+                WHERE user_id = 35
+            )
+            LIMIT 5
+            OFFSET 0;
+         */
+
+        sb.append("SELECT id, name, displayName, iconUrl, activeUsers, rank ")
+          .append("FROM ( ")
+            .append("SELECT cr.id AS id, cr.name AS name, cr.displayname AS displayName, cr.iconurl AS iconUrl, COUNT(DISTINCT user_id) AS activeUsers, RANK() OVER (ORDER BY COUNT(DISTINCT user_id) DESC, name) as rank ")
+            .append("FROM chatroom cr ")
+            .append("LEFT JOIN message m on cr.id = m.room_id ")
+            .append("WHERE m.createdate > (current_timestamp - interval '30 days') ")
+            .append("GROUP BY cr.id, cr.name, cr.displayname, cr.iconurl ")
+            .append("ORDER BY activeUsers DESC ")
+          .append(") AS ranked ")
+          .append("WHERE name <> 'breakerapp' AND id NOT IN ( ")
+            .append("SELECT room_id ")
+            .append("FROM userroom ");
+        if(userId != null)
+          sb.append("WHERE user_id = :userId ");
+          sb.append(") ")
+          .append("LIMIT :limit ")
+          .append("OFFSET :offset");
 
         Query activeRoomsQuery = JPA.em().createNativeQuery(sb.toString());
         activeRoomsQuery.setParameter("limit", limit);
         activeRoomsQuery.setParameter("offset", offset);
+        if(userId != null) activeRoomsQuery.setParameter("userId", userId);
 
         return convert(activeRoomsQuery.getResultList());
     }
@@ -41,7 +71,7 @@ public class ActiveRoomsService {
     private List<JsonActiveChatRoom> convert(List<Object[]> activeRoomsObjects) {
         List<JsonActiveChatRoom> activeRooms = new ArrayList<>();
         for(Object[] room : activeRoomsObjects) {
-            activeRooms.add(new JsonActiveChatRoom(room[0].toString(), room[1].toString(), (room[2] != null) ? room[2].toString() : "", Integer.parseInt(room[3].toString())));
+            activeRooms.add(new JsonActiveChatRoom(Integer.parseInt(room[0].toString()), room[1].toString(), room[2].toString(), (room[3] != null) ? room[3].toString() : "", Integer.parseInt(room[4].toString()),Integer.parseInt(room[5].toString())));
         }
 
         return activeRooms;

--- a/app/com/larvalabs/redditchat/services/JoinedRoomsService.java
+++ b/app/com/larvalabs/redditchat/services/JoinedRoomsService.java
@@ -1,0 +1,18 @@
+package com.larvalabs.redditchat.services;
+
+import models.ChatUser;
+import models.ChatUserRoomJoin;
+import play.db.jpa.JPA;
+
+import javax.persistence.Query;
+import java.util.List;
+
+public class JoinedRoomsService {
+    public static List<ChatUserRoomJoin> findJoinedRooms(ChatUser user) {
+        Query getAllStuffQuery = JPA.em().createQuery("select ur from ChatUserRoomJoin ur join fetch ur.room urr join fetch ur.user u where ur.room " +
+                "in (select room from ChatUserRoomJoin ur2 where ur2.user = :user) " +
+                "and ur.room.deleted = false and ur.room.open = true")
+                .setParameter("user", user);
+         return getAllStuffQuery.getResultList();
+    }
+}

--- a/app/com/larvalabs/redditchat/util/ActiveRoomsRedisUtil.java
+++ b/app/com/larvalabs/redditchat/util/ActiveRoomsRedisUtil.java
@@ -1,0 +1,75 @@
+package com.larvalabs.redditchat.util;
+
+import com.larvalabs.redditchat.dataobj.JsonActiveChatRoom;
+import play.Logger;
+import play.modules.redis.Redis;
+
+import java.io.*;
+import java.util.Collections;
+import java.util.List;
+
+public class ActiveRoomsRedisUtil {
+
+    private static final String ACTIVE_ROOMS_KEY = "ACTIVE_ROOMS";
+    private static final int ACTIVE_ROOMS_EXPIRE = 600; // 10 minutes
+
+    public static List<JsonActiveChatRoom> getActiveRooms() {
+        String rooms = Redis.get(ACTIVE_ROOMS_KEY);
+        if(rooms != null) {
+            return deserialize(rooms.getBytes());
+        }
+
+        return Collections.emptyList();
+    }
+
+    public static String cacheActiveRooms(List<JsonActiveChatRoom> activeRoomsList) {
+        byte[] activeRooms = serializeToBytes(activeRoomsList);
+        return Redis.setex(ACTIVE_ROOMS_KEY, ACTIVE_ROOMS_EXPIRE, String.valueOf(activeRooms));
+    }
+
+    private static byte[] serializeToBytes(List<JsonActiveChatRoom> list) {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = null;
+        try {
+            oos = new ObjectOutputStream(bos);
+            oos.writeObject(list);
+            oos.flush();
+        } catch (IOException e) {
+            Logger.error(e, "Error converting active rooms list to byte array.");
+            e.printStackTrace();
+            return new byte[0];
+        } finally {
+            closeStream(oos);
+        }
+
+        return bos.toByteArray();
+    }
+
+    private static List<JsonActiveChatRoom> deserialize(byte[] activeRooms) {
+        ByteArrayInputStream bis = new ByteArrayInputStream(activeRooms);
+        ObjectInput in = null;
+        try {
+            in = new ObjectInputStream(bis);
+            return (List<JsonActiveChatRoom>) in.readObject();
+        } catch (IOException e) {
+            Logger.error(e, "Error reading active rooms byte array.");
+            e.printStackTrace();
+        } catch (ClassNotFoundException e) {
+            Logger.error(e, "Error converting active rooms byte array to list.");
+            e.printStackTrace();
+        } finally {
+            closeStream(bis);
+        }
+        return Collections.emptyList();
+    }
+
+    private static void closeStream(Closeable closeable) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (IOException ex) {
+                // important exceptions already handled
+            }
+        }
+    }
+}

--- a/app/com/larvalabs/redditchat/util/ActiveRoomsRedisUtil.java
+++ b/app/com/larvalabs/redditchat/util/ActiveRoomsRedisUtil.java
@@ -54,13 +54,14 @@ public class ActiveRoomsRedisUtil {
         } catch (IOException e) {
             Logger.error(e, "Error reading active rooms byte array.");
             e.printStackTrace();
+            return Collections.emptyList();
         } catch (ClassNotFoundException e) {
             Logger.error(e, "Error converting active rooms byte array to list.");
             e.printStackTrace();
+            return Collections.emptyList();
         } finally {
             closeStream(bis);
         }
-        return Collections.emptyList();
     }
 
     private static void closeStream(Closeable closeable) {

--- a/app/com/larvalabs/redditchat/util/RedisConstants.java
+++ b/app/com/larvalabs/redditchat/util/RedisConstants.java
@@ -1,0 +1,6 @@
+package com.larvalabs.redditchat.util;
+
+public class RedisConstants {
+    public static final String REDISKEY_PRESENCE_GLOBAL = "presence__global";
+    public static final double CHANCE_CLEAN_REDIS_PRESENCE = 0.01;
+}

--- a/app/com/larvalabs/redditchat/util/RedisUtil.java
+++ b/app/com/larvalabs/redditchat/util/RedisUtil.java
@@ -1,6 +1,7 @@
 package com.larvalabs.redditchat.util;
 
 import com.larvalabs.redditchat.Constants;
+import com.larvalabs.redditchat.dataobj.JsonActiveChatRoom;
 import com.sun.istack.internal.Nullable;
 import models.ChatUser;
 import models.ChatUserRoomJoin;
@@ -20,8 +21,8 @@ import java.util.TreeSet;
  */
 public class RedisUtil {
 
-    public static final String REDISKEY_PRESENCE_GLOBAL = "presence__global";
-    public static final double CHANCE_CLEAN_REDIS_PRESENCE = 0.01;
+    public static final String REDISKEY_PRESENCE_GLOBAL = RedisConstants.REDISKEY_PRESENCE_GLOBAL;
+    public static final double CHANCE_CLEAN_REDIS_PRESENCE = RedisConstants.CHANCE_CLEAN_REDIS_PRESENCE;
 
     private static Random random = new Random();
 
@@ -198,6 +199,10 @@ public class RedisUtil {
             Logger.error("Error contacting redis.");
             return 0;
         }
+    }
+
+    public static List<JsonActiveChatRoom> getMostActiveChatRooms() {
+        return null;
     }
 
 }

--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -529,11 +529,10 @@ public class Application extends PreloadUserController {
     public static void getActiveRooms(Integer limit, Integer offset) {
         ChatUser connected = connected();
 
-        Long userId = (connected == null) ? null : connected.getId();
         if(limit == null || limit > 25) limit = 10; //load max 25 Rooms
         if(offset == null) offset = 0;
 
-        List<JsonActiveChatRoom> activeChatRooms = ActiveRoomsService.findMostActiveRooms(limit, offset, userId);
+        HashMap<String, JsonActiveChatRoom> activeChatRooms = JsonActiveRoomsUtil.getActiveRooms(connected, offset, limit);
         renderJSON(activeChatRooms);
     }
 

--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject;
 import com.larvalabs.redditchat.Constants;
 import com.larvalabs.redditchat.dataobj.*;
 import com.larvalabs.redditchat.realtime.ChatRoomStream;
+import com.larvalabs.redditchat.services.ActiveRoomsService;
 import com.larvalabs.redditchat.util.RedditUtil;
 import com.larvalabs.redditchat.util.RedisUtil;
 import com.larvalabs.redditchat.util.Util;
@@ -452,6 +453,14 @@ public class Application extends PreloadUserController {
             jsonMessages.add(JsonMessage.from(message, message.getUser().getUsername(), room.getName()));
         }
         renderJSON(jsonMessages);
+    }
+
+    public static void getActiveRooms(Integer limit, Integer offset) {
+        if(limit == null || limit > 25) limit = 10; //load max 25 Rooms
+        if(offset == null) offset = 0;
+
+        List<JsonActiveChatRoom> activeChatRooms = ActiveRoomsService.getInstance().findMostActiveRooms(limit, offset);
+        renderJSON(activeChatRooms);
     }
 
     /*

--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -456,10 +456,13 @@ public class Application extends PreloadUserController {
     }
 
     public static void getActiveRooms(Integer limit, Integer offset) {
+        ChatUser connected = connected();
+
+        Long userId = (connected == null) ? null : connected.getId();
         if(limit == null || limit > 25) limit = 10; //load max 25 Rooms
         if(offset == null) offset = 0;
 
-        List<JsonActiveChatRoom> activeChatRooms = ActiveRoomsService.getInstance().findMostActiveRooms(limit, offset);
+        List<JsonActiveChatRoom> activeChatRooms = ActiveRoomsService.getInstance().findMostActiveRooms(limit, offset, userId);
         renderJSON(activeChatRooms);
     }
 

--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -462,7 +462,7 @@ public class Application extends PreloadUserController {
         if(limit == null || limit > 25) limit = 10; //load max 25 Rooms
         if(offset == null) offset = 0;
 
-        List<JsonActiveChatRoom> activeChatRooms = ActiveRoomsService.getInstance().findMostActiveRooms(limit, offset, userId);
+        List<JsonActiveChatRoom> activeChatRooms = ActiveRoomsService.findMostActiveRooms(limit, offset, userId);
         renderJSON(activeChatRooms);
     }
 

--- a/app/controllers/WebSocket.java
+++ b/app/controllers/WebSocket.java
@@ -129,7 +129,7 @@ public class WebSocket extends PreloadUserController {
         JsonUtil.FullState fullState = JsonUtil.loadFullStateForUser(user);
 
         TreeMap<String, JsonChatRoom> rooms = fullState.rooms;
-        Map<Integer, JsonActiveChatRoom> activeRooms = fullState.activeRooms;
+        Map<String, JsonActiveChatRoom> activeRooms = fullState.activeRooms;
         TreeMap<String, JsonUser> allUsers = fullState.users;
         TreeMap<String, JsonRoomMembers> members = fullState.members;
         TreeMap<String, ArrayList<String>> roomMessages = fullState.roomMessages;

--- a/app/controllers/WebSocket.java
+++ b/app/controllers/WebSocket.java
@@ -129,6 +129,7 @@ public class WebSocket extends PreloadUserController {
         JsonUtil.FullState fullState = JsonUtil.loadFullStateForUser(user);
 
         TreeMap<String, JsonChatRoom> rooms = fullState.rooms;
+        Map<Integer, JsonActiveChatRoom> activeRooms = fullState.activeRooms;
         TreeMap<String, JsonUser> allUsers = fullState.users;
         TreeMap<String, JsonRoomMembers> members = fullState.members;
         TreeMap<String, ArrayList<String>> roomMessages = fullState.roomMessages;
@@ -141,6 +142,7 @@ public class WebSocket extends PreloadUserController {
         String usersString = gson.toJson(allUsers);
         String membersString = gson.toJson(members);
         String roomMessagesString = gson.toJson(roomMessages);
+        String activeRoomsString = gson.toJson(activeRooms);
         String messagesString = gson.toJson(messages);
         String lastSeenTimesString = gson.toJson(fullState.lastSeenTimes);
         long loadTime = System.currentTimeMillis() - startTime;
@@ -148,7 +150,7 @@ public class WebSocket extends PreloadUserController {
         Stats.measure(Stats.StatKey.INITIALPAGE_TIME, loadTime);
 
         // Links to other suggested rooms
-        List<ChatRoom> activeRooms = new ArrayList<ChatRoom>();
+        //List<ChatRoom> activeRooms = new ArrayList<ChatRoom>();
 /*
         {
             ChatRoom breakerapp = ChatRoom.findByName("breakerapp");
@@ -182,7 +184,7 @@ public class WebSocket extends PreloadUserController {
 
         Logger.info("Websocket room time for " + user.getUsername() + ": " + (System.currentTimeMillis() - startTime));
 
-        render("index.html", user, rooms, userString, roomName, environment, roomsString, usersString, membersString,
+        render("index.html", user, rooms, userString, roomName, environment, roomsString, activeRoomsString, usersString, membersString,
                 roomMessagesString, messagesString, lastSeenTimesString);
     }
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -52,6 +52,7 @@
                 currentRoom: "${roomName}",
                 members: ${membersString.raw()},
                 rooms: ${roomsString.raw()},
+                activeRooms: ${activeRoomsString.raw()},
                 users: ${usersString.raw()},
                 roomMessages: ${roomMessagesString.raw()},
                 messages: ${messagesString.raw()},

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -350,3 +350,7 @@ li.chat-message-root .message-body, li.chat-message-short .message-body, li.chat
   content: none !important;
 }
 
+.hoverable:hover {
+  cursor: pointer;
+}
+

--- a/web/api.js
+++ b/web/api.js
@@ -12,6 +12,10 @@ const API = {
 
   fetchMoreMessages(roomName, fromMessageId, count) {
     return request.get(`/application/getmessages?roomName=${roomName}&id=${fromMessageId}&limit=${count}&before=true`);
+  },
+
+  fetchMoreActiveRooms(limit, offset) {
+    return request.get(`/application/getactiverooms?limit=${limit}&offset=${offset}`);
   }
 };
 

--- a/web/redux/actions/active-rooms-actions.js
+++ b/web/redux/actions/active-rooms-actions.js
@@ -20,6 +20,16 @@ export function setActiveRoomsComplete() {
   return { type: actions.ACTIVE_ROOMS_COMPLETE };
 }
 
+export function resetActiveRooms() {
+  return { type: actions.ACTIVE_ROOMS_RESET };
+}
+
+export function handleResetActiveRooms() {
+  return (dispatch) => {
+    dispatch(resetActiveRooms());
+  };
+}
+
 export function handleMoreActiveRooms() {
   return (dispatch, getState) => {
     const limit = 10;

--- a/web/redux/actions/active-rooms-actions.js
+++ b/web/redux/actions/active-rooms-actions.js
@@ -1,0 +1,29 @@
+import * as actions from '../constants/active-rooms-contants';
+
+export function loadingMoreActiveRooms() {
+    return { type: actions.ACTIVE_ROOMS_LOADING_MORE };
+}
+
+export function loadedMoreActiveRooms(activeRooms) {
+    return { type: actions.ACTIVE_ROOMS_LOADED_MORE, activeRooms };
+}
+
+export function failedLoadingMoreActiveRooms(error) {
+    return null;
+}
+
+export function handleMoreActiveRooms() {
+    return (dispatch, getState) => {
+        const state = getState();
+        const limit = 10;
+        const offset = 5;
+
+        dispatch(loadingMoreActiveRooms());
+        API.fetchMoreActiveRooms(limit, offset)
+            .then(response => {
+               dispatch(loadedMoreActiveRooms(response.data));
+            }).catch(error => {
+                dispatch(failedLoadingMoreActiveRooms(error));
+            });
+    }
+}

--- a/web/redux/actions/active-rooms-actions.js
+++ b/web/redux/actions/active-rooms-actions.js
@@ -28,7 +28,7 @@ export function handleMoreActiveRooms() {
     dispatch(loadingMoreActiveRooms());
     API.fetchMoreActiveRooms(limit, offset)
       .then(response => {
-        if (response.data.length <= 10) {
+        if (response.data.length < 10) {
           dispatch(setActiveRoomsComplete());
         }
         dispatch(loadedMoreActiveRooms(response.data));

--- a/web/redux/actions/active-rooms-actions.js
+++ b/web/redux/actions/active-rooms-actions.js
@@ -1,42 +1,45 @@
-import Immutable from 'immutable';
-
 import API from '../../api';
 
 import * as actions from '../constants/active-rooms-contants';
 
 
 export function loadingMoreActiveRooms() {
-  return {type: actions.ACTIVE_ROOMS_LOADING_MORE};
+  return { type: actions.ACTIVE_ROOMS_LOADING_MORE };
 }
 
 export function loadedMoreActiveRooms(activeRooms) {
-  return {type: actions.ACTIVE_ROOMS_LOADED_MORE, activeRooms};
+  return { type: actions.ACTIVE_ROOMS_LOADED_MORE, activeRooms };
 }
 
 export function failedLoadingMoreActiveRooms(error) {
-  return null;
+  return { type: actions.ACTIVE_ROOMS_FAILED_LOADING_MORE, error };
+}
+
+export function setActiveRoomsComplete() {
+  return { type: actions.ACTIVE_ROOMS_COMPLETE };
 }
 
 export function loadMoreActiveRooms() {
   const findLastRank = (activeRoomsState) => {
     let rank = 0;
     activeRoomsState.toArray().forEach(room => {
-      if(rank < room.get('rank')) rank = room.get('rank');
+      if (rank < room.get('rank')) rank = room.get('rank');
     });
     return rank;
   };
 
   return (dispatch, getState) => {
-    const state = getState().get("activeRooms");
+    const state = getState().get('activeRooms');
     const limit = 10;
     const offset = findLastRank(state);
 
     dispatch(loadingMoreActiveRooms());
     API.fetchMoreActiveRooms(limit, offset)
       .then(response => {
+        if (response.data.length <= 10) dispatch(setActiveRoomsComplete());
         dispatch(loadedMoreActiveRooms(response.data));
       }).catch(error => {
-      dispatch(failedLoadingMoreActiveRooms(error));
-    });
-  }
+        dispatch(failedLoadingMoreActiveRooms(error));
+      });
+  };
 }

--- a/web/redux/actions/active-rooms-actions.js
+++ b/web/redux/actions/active-rooms-actions.js
@@ -28,7 +28,7 @@ export function handleMoreActiveRooms() {
     dispatch(loadingMoreActiveRooms());
     API.fetchMoreActiveRooms(limit, offset)
       .then(response => {
-        if (response.data.length < 10) {
+        if (Object.keys(response.data).length < 10) {
           dispatch(setActiveRoomsComplete());
         }
         dispatch(loadedMoreActiveRooms(response.data));

--- a/web/redux/actions/active-rooms-actions.js
+++ b/web/redux/actions/active-rooms-actions.js
@@ -19,7 +19,7 @@ export function setActiveRoomsComplete() {
   return { type: actions.ACTIVE_ROOMS_COMPLETE };
 }
 
-export function loadMoreActiveRooms() {
+export function handleMoreActiveRooms() {
   const findLastRank = (activeRoomsState) => {
     let rank = 0;
     activeRoomsState.toArray().forEach(room => {
@@ -29,14 +29,16 @@ export function loadMoreActiveRooms() {
   };
 
   return (dispatch, getState) => {
-    const state = getState().get('activeRooms');
+    const activeRoomsState = getState().get('activeRooms');
     const limit = 10;
-    const offset = findLastRank(state);
+    const offset = findLastRank(activeRoomsState);
 
     dispatch(loadingMoreActiveRooms());
     API.fetchMoreActiveRooms(limit, offset)
       .then(response => {
-        if (response.data.length <= 10) dispatch(setActiveRoomsComplete());
+        if (response.data.length <= 10) {
+          dispatch(setActiveRoomsComplete());
+        }
         dispatch(loadedMoreActiveRooms(response.data));
       }).catch(error => {
         dispatch(failedLoadingMoreActiveRooms(error));

--- a/web/redux/actions/active-rooms-actions.js
+++ b/web/redux/actions/active-rooms-actions.js
@@ -1,6 +1,7 @@
 import API from '../../api';
 
 import * as actions from '../constants/active-rooms-contants';
+import { findLastRank } from '../selectors/active-rooms-selector';
 
 
 export function loadingMoreActiveRooms() {
@@ -20,18 +21,9 @@ export function setActiveRoomsComplete() {
 }
 
 export function handleMoreActiveRooms() {
-  const findLastRank = (activeRoomsState) => {
-    let rank = 0;
-    activeRoomsState.toArray().forEach(room => {
-      if (rank < room.get('rank')) rank = room.get('rank');
-    });
-    return rank;
-  };
-
   return (dispatch, getState) => {
-    const activeRoomsState = getState().get('activeRooms');
     const limit = 10;
-    const offset = findLastRank(activeRoomsState);
+    const offset = findLastRank(getState());
 
     dispatch(loadingMoreActiveRooms());
     API.fetchMoreActiveRooms(limit, offset)

--- a/web/redux/actions/active-rooms-actions.js
+++ b/web/redux/actions/active-rooms-actions.js
@@ -20,14 +20,8 @@ export function setActiveRoomsComplete() {
   return { type: actions.ACTIVE_ROOMS_COMPLETE };
 }
 
-export function resetActiveRooms() {
+export function resetActiveRoomsList() {
   return { type: actions.ACTIVE_ROOMS_RESET };
-}
-
-export function handleResetActiveRooms() {
-  return (dispatch) => {
-    dispatch(resetActiveRooms());
-  };
 }
 
 export function handleMoreActiveRooms() {

--- a/web/redux/actions/active-rooms-actions.js
+++ b/web/redux/actions/active-rooms-actions.js
@@ -1,29 +1,42 @@
+import Immutable from 'immutable';
+
+import API from '../../api';
+
 import * as actions from '../constants/active-rooms-contants';
 
+
 export function loadingMoreActiveRooms() {
-    return { type: actions.ACTIVE_ROOMS_LOADING_MORE };
+  return {type: actions.ACTIVE_ROOMS_LOADING_MORE};
 }
 
 export function loadedMoreActiveRooms(activeRooms) {
-    return { type: actions.ACTIVE_ROOMS_LOADED_MORE, activeRooms };
+  return {type: actions.ACTIVE_ROOMS_LOADED_MORE, activeRooms};
 }
 
 export function failedLoadingMoreActiveRooms(error) {
-    return null;
+  return null;
 }
 
-export function handleMoreActiveRooms() {
-    return (dispatch, getState) => {
-        const state = getState();
-        const limit = 10;
-        const offset = 5;
+export function loadMoreActiveRooms() {
+  const findLastRank = (activeRoomsState) => {
+    let rank = 0;
+    activeRoomsState.toArray().forEach(room => {
+      if(rank < room.get('rank')) rank = room.get('rank');
+    });
+    return rank;
+  };
 
-        dispatch(loadingMoreActiveRooms());
-        API.fetchMoreActiveRooms(limit, offset)
-            .then(response => {
-               dispatch(loadedMoreActiveRooms(response.data));
-            }).catch(error => {
-                dispatch(failedLoadingMoreActiveRooms(error));
-            });
-    }
+  return (dispatch, getState) => {
+    const state = getState().get("activeRooms");
+    const limit = 10;
+    const offset = findLastRank(state);
+
+    dispatch(loadingMoreActiveRooms());
+    API.fetchMoreActiveRooms(limit, offset)
+      .then(response => {
+        dispatch(loadedMoreActiveRooms(response.data));
+      }).catch(error => {
+      dispatch(failedLoadingMoreActiveRooms(error));
+    });
+  }
 }

--- a/web/redux/constants/active-rooms-contants.js
+++ b/web/redux/constants/active-rooms-contants.js
@@ -1,2 +1,3 @@
 export const ACTIVE_ROOMS_LOADING_MORE = 'active-rooms-loading-more';
 export const ACTIVE_ROOMS_LOADED_MORE = 'active-rooms-loaded-more';
+export const ACTIVE_ROOMS_FAILED_LOADING_MORE = 'active-rooms-failed-loading-more';

--- a/web/redux/constants/active-rooms-contants.js
+++ b/web/redux/constants/active-rooms-contants.js
@@ -2,3 +2,4 @@ export const ACTIVE_ROOMS_LOADING_MORE = 'active-rooms-loading-more';
 export const ACTIVE_ROOMS_LOADED_MORE = 'active-rooms-loaded-more';
 export const ACTIVE_ROOMS_FAILED_LOADING_MORE = 'active-rooms-failed-loading-more';
 export const ACTIVE_ROOMS_COMPLETE = 'active-rooms-complete';
+export const ACTIVE_ROOMS_RESET = 'active-rooms-reset';

--- a/web/redux/constants/active-rooms-contants.js
+++ b/web/redux/constants/active-rooms-contants.js
@@ -1,3 +1,4 @@
 export const ACTIVE_ROOMS_LOADING_MORE = 'active-rooms-loading-more';
 export const ACTIVE_ROOMS_LOADED_MORE = 'active-rooms-loaded-more';
 export const ACTIVE_ROOMS_FAILED_LOADING_MORE = 'active-rooms-failed-loading-more';
+export const ACTIVE_ROOMS_COMPLETE = 'active-rooms-complete';

--- a/web/redux/constants/active-rooms-contants.js
+++ b/web/redux/constants/active-rooms-contants.js
@@ -1,0 +1,2 @@
+export const ACTIVE_ROOMS_LOADING_MORE = 'active-rooms-loading-more';
+export const ACTIVE_ROOMS_LOADED_MORE = 'active-rooms-loaded-more';

--- a/web/redux/reducers/active-rooms-reducer.js
+++ b/web/redux/reducers/active-rooms-reducer.js
@@ -4,11 +4,10 @@ import * as activeRoomsTypes from '../constants/active-rooms-contants';
 
 export default function activeRooms(state = Immutable.Map(), action) {
   switch (action.type) {
-    case(activeRoomsTypes.ACTIVE_ROOMS_LOADED_MORE): {
-      console.log("REDUCER action: ", action);
+    case (activeRoomsTypes.ACTIVE_ROOMS_LOADED_MORE): {
       return state.merge(Immutable.fromJS(action.activeRooms.reduce((obj, room) => {
         const newObj = obj;
-        newObj[room.rank] = room;
+        newObj[room.name] = room;
         return newObj;
       }, {})));
     }

--- a/web/redux/reducers/active-rooms-reducer.js
+++ b/web/redux/reducers/active-rooms-reducer.js
@@ -5,11 +5,7 @@ import * as activeRoomsTypes from '../constants/active-rooms-contants';
 export default function activeRooms(state = Immutable.Map(), action) {
   switch (action.type) {
     case (activeRoomsTypes.ACTIVE_ROOMS_LOADED_MORE): {
-      return state.merge(Immutable.fromJS(action.activeRooms.reduce((obj, room) => {
-        const newObj = obj;
-        newObj[room.name] = room;
-        return newObj;
-      }, {})));
+      return state.merge(Immutable.fromJS(action.activeRooms));
     }
     default:
       return state;

--- a/web/redux/reducers/active-rooms-reducer.js
+++ b/web/redux/reducers/active-rooms-reducer.js
@@ -7,6 +7,9 @@ export default function activeRooms(state = Immutable.Map(), action) {
     case (activeRoomsTypes.ACTIVE_ROOMS_LOADED_MORE): {
       return state.merge(Immutable.fromJS(action.activeRooms));
     }
+    case (activeRoomsTypes.ACTIVE_ROOMS_RESET): {
+      return state.slice(0, 5);
+    }
     default:
       return state;
   }

--- a/web/redux/reducers/active-rooms-reducer.js
+++ b/web/redux/reducers/active-rooms-reducer.js
@@ -1,8 +1,18 @@
 import Immutable from 'immutable';
 
+import * as activeRoomsTypes from '../constants/active-rooms-contants';
+
 export default function activeRooms(state = Immutable.Map(), action) {
-    switch (action.type) {
-        default:
-            return state;
+  switch (action.type) {
+    case(activeRoomsTypes.ACTIVE_ROOMS_LOADED_MORE): {
+      console.log("REDUCER action: ", action);
+      return state.merge(Immutable.fromJS(action.activeRooms.reduce((obj, room) => {
+        const newObj = obj;
+        newObj[room.rank] = room;
+        return newObj;
+      }, {})));
     }
+    default:
+      return state;
+  }
 }

--- a/web/redux/reducers/active-rooms-reducer.js
+++ b/web/redux/reducers/active-rooms-reducer.js
@@ -1,0 +1,8 @@
+import Immutable from 'immutable';
+
+export default function activeRooms(state = Immutable.Map(), action) {
+    switch (action.type) {
+        default:
+            return state;
+    }
+}

--- a/web/redux/reducers/root-reducer.js
+++ b/web/redux/reducers/root-reducer.js
@@ -4,6 +4,7 @@ import Immutable from 'immutable';
 import ui from './ui-reducer';
 import bannerMessage from './banner-message-reducer';
 import currentRoom from './current-room-reducer';
+import activeRooms from './active-rooms-reducer';
 import members from './members-reducer';
 import roomMessages from './room-messages-reducer';
 import messages from './message-entites-reducer';
@@ -23,6 +24,7 @@ const App = combineReducers({
   members,
   users,
   rooms,
+  activeRooms,
   roomMessages,
   messages,
   bannerMessage,

--- a/web/redux/reducers/ui-reducer.js
+++ b/web/redux/reducers/ui-reducer.js
@@ -90,6 +90,9 @@ export default function ui(state = initialState, action) {
     case (activeRoomsTypes.ACTIVE_ROOMS_FAILED_LOADING_MORE): {
       return state.set('moreActiveRoomsLoading', false);
     }
+    case (activeRoomsTypes.ACTIVE_ROOMS_COMPLETE): {
+      return state.set('activeRoomsComplete', true);
+    }
     default: {
       return state;
     }

--- a/web/redux/reducers/ui-reducer.js
+++ b/web/redux/reducers/ui-reducer.js
@@ -4,6 +4,7 @@ import * as menuTypes from '../constants/menu-constants';
 import * as socketTypes from '../constants/socket-constants';
 import * as chatTypes from '../constants/chat-constants';
 import * as scrollTypes from '../constants/scroll-constants';
+import * as activeRoomsTypes from '../constants/active-rooms-contants';
 
 
 const initialState = Immutable.Map({
@@ -79,6 +80,15 @@ export default function ui(state = initialState, action) {
     }
     case (chatTypes.CHAT_ROOM_CHANGED): {
       return state.set('__HAS_FOCUS__', true);
+    }
+    case (activeRoomsTypes.ACTIVE_ROOMS_LOADING_MORE): {
+      return state.set('moreActiveRoomsLoading', true);
+    }
+    case (activeRoomsTypes.ACTIVE_ROOMS_LOADED_MORE): {
+      return state.set('moreActiveRoomsLoading', false);
+    }
+    case (activeRoomsTypes.ACTIVE_ROOMS_FAILED_LOADING_MORE): {
+      return state.set('moreActiveRoomsLoading', false);
     }
     default: {
       return state;

--- a/web/redux/reducers/ui-reducer.js
+++ b/web/redux/reducers/ui-reducer.js
@@ -93,6 +93,9 @@ export default function ui(state = initialState, action) {
     case (activeRoomsTypes.ACTIVE_ROOMS_COMPLETE): {
       return state.set('activeRoomsComplete', true);
     }
+    case (activeRoomsTypes.ACTIVE_ROOMS_RESET): {
+      return state.set('activeRoomsComplete', false);
+    }
     default: {
       return state;
     }

--- a/web/redux/selectors/active-rooms-selector.js
+++ b/web/redux/selectors/active-rooms-selector.js
@@ -3,9 +3,8 @@ import { createSelector } from 'reselect';
 const getActiveRooms = (state) => state.get('activeRooms');
 
 export const getAllActiveRooms = createSelector(
-    [getActiveRooms],
-    (activeRooms) => {
-        console.log("ACTIVE CHANNELS IN SELECTOR: ", activeRooms);
-        return activeRooms;
-    }
+  [getActiveRooms],
+  (activeRooms) => {
+    return activeRooms;
+  }
 );

--- a/web/redux/selectors/active-rooms-selector.js
+++ b/web/redux/selectors/active-rooms-selector.js
@@ -1,0 +1,11 @@
+import { createSelector } from 'reselect';
+
+const getActiveRooms = (state) => state.get('activeRooms');
+
+export const getAllActiveRooms = createSelector(
+    [getActiveRooms],
+    (activeRooms) => {
+        console.log("ACTIVE CHANNELS IN SELECTOR: ", activeRooms);
+        return activeRooms;
+    }
+);

--- a/web/redux/selectors/active-rooms-selector.js
+++ b/web/redux/selectors/active-rooms-selector.js
@@ -8,3 +8,16 @@ export const getAllActiveRooms = createSelector(
     return activeRooms;
   }
 );
+
+export const findLastRank = createSelector(
+  [getActiveRooms],
+  (activeRooms) => {
+    let rank = 0;
+    activeRooms.toArray().forEach(room => {
+      if (rank < room.get('rank')) {
+        rank = room.get('rank');
+      }
+    });
+    return rank;
+  }
+);

--- a/web/redux/selectors/ui-selectors.js
+++ b/web/redux/selectors/ui-selectors.js
@@ -41,6 +41,13 @@ export const getMoreMessagesLoading = createSelector(
     }
 );
 
+export const getMoreActiveRoomsLoading = createSelector(
+  [getUi],
+  (ui) => {
+    return ui.get('moreActiveRoomsLoading', false);
+  }
+)
+
 export const getConnected = createSelector(
     [getUi],
     (ui) => {

--- a/web/redux/selectors/ui-selectors.js
+++ b/web/redux/selectors/ui-selectors.js
@@ -46,7 +46,14 @@ export const getMoreActiveRoomsLoading = createSelector(
   (ui) => {
     return ui.get('moreActiveRoomsLoading', false);
   }
-)
+);
+
+export const isActiveRoomsComplete = createSelector(
+  [getUi],
+  (ui) => {
+    return ui.get('activeRoomsComplete', false);
+  }
+);
 
 export const getConnected = createSelector(
     [getUi],

--- a/web/sidebar/Sidebar.jsx
+++ b/web/sidebar/Sidebar.jsx
@@ -26,6 +26,10 @@ class Sidebar extends Component {
     }
   }
 
+  getOrderedActiveRooms() {
+    return this.props.activeRoomList.toArray().sort((a, b) => a.get('rank') - b.get('rank'));
+  }
+
   renderYourRooms() {
     const sidebarColor = this.props.room.getIn(['styles', 'sidebarTextColor']);
     const yourRoomsStyles = { color: sidebarColor };
@@ -82,7 +86,7 @@ class Sidebar extends Component {
           <span style={activeRoomsStyles}>Active Rooms</span>
         </li>
         {
-          this.props.activeRoomList.toArray().map((room) => {
+          this.getOrderedActiveRooms().map((room) => {
             return (
               <SidebarActiveRoom key={room.get('name')}
                                  room={room}

--- a/web/sidebar/Sidebar.jsx
+++ b/web/sidebar/Sidebar.jsx
@@ -6,10 +6,12 @@ import Immutable from 'immutable';
 import Config from '../config';
 
 import SidebarRoomRoom from './SidebarRoom';
+import { SidebarActiveRoom } from './SidebarActiveRoom';
 
 import { scrollToRoomNameReset } from '../redux/actions/scroll-actions';
 import { getSidebarOpen, getScrollToRoomName } from '../redux/selectors/ui-selectors';
 import { getAllRooms, getCurrentRoom, getCurrentRoomStyles } from '../redux/selectors/rooms-selectors';
+import { getAllActiveRooms } from '../redux/selectors/active-rooms-selector';
 
 
 class Sidebar extends Component {
@@ -46,6 +48,33 @@ class Sidebar extends Component {
     );
   }
 
+  renderActiveRooms() {
+    const sidebarColor = this.props.room.getIn(['styles', 'sidebarTextColor']);
+    const activeRoomsStyles = { color: sidebarColor };
+    const moreBtnStyles = { paddingLeft: "40px", margin: 0 }
+
+    return (
+        <ul id="roomlist" className="nav">
+          <li key="active-rooms" className="hidden-folded padder m-t m-b-sm text-muted text-xs">
+            <span style={activeRoomsStyles}>Active Rooms</span>
+          </li>
+          {
+            this.props.activeRoomList.toArray().map((room) => {
+              return (
+                  <SidebarActiveRoom key={room.get('name')}
+                                   room={room}
+                                   styles={this.props.styles}
+                  />
+              );
+            })
+          }
+          <li className="hidden-folded m-t m-b-sm text-muted" style={moreBtnStyles}>
+            <a><b>+ more</b></a>
+          </li>
+        </ul>
+    );
+  }
+
   render() {
     const styles = Config.styles.getSidebarColorForRoom(this.props.room);
 
@@ -60,6 +89,7 @@ class Sidebar extends Component {
           <div className="navi-wrap" ref="roomList">
             <nav ui-nav className="navi clearfix">
               {this.renderYourRooms()}
+              {this.renderActiveRooms()}
             </nav>
           </div>
         </div>
@@ -85,6 +115,7 @@ function mapStateToProps(state) {
     room: getCurrentRoom(state),
     roomName: state.get('currentRoom'),
     roomList: getAllRooms(state),
+    activeRoomList: getAllActiveRooms(state),
     scrollToRoomName: getScrollToRoomName(state)
   };
 }

--- a/web/sidebar/Sidebar.jsx
+++ b/web/sidebar/Sidebar.jsx
@@ -11,7 +11,7 @@ import { SidebarActiveRoom } from './SidebarActiveRoom';
 import { scrollToRoomNameReset } from '../redux/actions/scroll-actions';
 import { loadMoreActiveRooms } from '../redux/actions/active-rooms-actions';
 
-import { getSidebarOpen, getScrollToRoomName, getMoreActiveRoomsLoading } from '../redux/selectors/ui-selectors';
+import { getSidebarOpen, getScrollToRoomName, getMoreActiveRoomsLoading, isActiveRoomsComplete } from '../redux/selectors/ui-selectors';
 import { getAllRooms, getCurrentRoom, getCurrentRoomStyles } from '../redux/selectors/rooms-selectors';
 import { getAllActiveRooms } from '../redux/selectors/active-rooms-selector';
 
@@ -37,12 +37,12 @@ class Sidebar extends Component {
         {
           this.props.roomList.toArray().map((room) => {
             return (
-                <SidebarRoomRoom key={room.get('name')}
-                                 ref={room.get('name')}
-                                 room={room}
-                                 active={room.get('name') === this.props.roomName}
-                                 styles={this.props.styles}
-                />
+              <SidebarRoomRoom key={room.get('name')}
+                               ref={room.get('name')}
+                               room={room}
+                               active={room.get('name') === this.props.roomName}
+                               styles={this.props.styles}
+              />
             );
           })
         }
@@ -51,7 +51,7 @@ class Sidebar extends Component {
   }
 
   renderLoadingIndicator() {
-    const indicatorStyles = { fontSize: "0.5em", margin: "5px 60px" };
+    const indicatorStyles = { fontSize: '0.5em', margin: '5px 60px' };
     return (
       <div style={indicatorStyles}>
         <i className="fa fa-circle-o-notch fa-spin fa-3x fa-fw"></i>
@@ -61,8 +61,8 @@ class Sidebar extends Component {
   }
 
   renderMoreActiveRoomsButton() {
-    const { activeRoomsLoading } =  this.props;
-    const moreBtnStyles = { paddingLeft: "40px", margin: 0 };
+    const { activeRoomsLoading } = this.props;
+    const moreBtnStyles = { paddingLeft: '40px', margin: 0 };
 
     return (
       <li className="hidden-folded m-t m-b-sm text-muted" style={moreBtnStyles} onClick={this.props.moreActiveRooms}>
@@ -74,26 +74,26 @@ class Sidebar extends Component {
   renderActiveRooms() {
     const sidebarColor = this.props.room.getIn(['styles', 'sidebarTextColor']);
     const activeRoomsStyles = { color: sidebarColor };
-
+    const { isActiveRoomsCompleted } = this.props;
 
     return (
-        <ul id="roomlist" className="nav">
-          <li key="active-rooms" className="hidden-folded padder m-t m-b-sm text-muted text-xs">
-            <span style={activeRoomsStyles}>Active Rooms</span>
-          </li>
-          {
-            this.props.activeRoomList.toArray().map((room) => {
-              return (
-                  <SidebarActiveRoom key={room.get('name')}
-                                   room={room}
-                                   styles={this.props.styles}
-                  />
-              );
-            })
-          }
-          {(this.props.activeRoomList.toArray().length > 4) ? this.renderMoreActiveRoomsButton() : null}
+      <ul id="roomlist" className="nav">
+        <li key="active-rooms" className="hidden-folded padder m-t m-b-sm text-muted text-xs">
+          <span style={activeRoomsStyles}>Active Rooms</span>
+        </li>
+        {
+          this.props.activeRoomList.toArray().map((room) => {
+            return (
+              <SidebarActiveRoom key={room.get('name')}
+                                 room={room}
+                                 styles={this.props.styles}
+              />
+            );
+          })
+        }
+        {(this.props.activeRoomList.toArray().length > 4 && !isActiveRoomsCompleted) ? this.renderMoreActiveRoomsButton() : null}
 
-        </ul>
+      </ul>
     );
   }
 
@@ -111,7 +111,7 @@ class Sidebar extends Component {
           <div className="navi-wrap" ref="roomList">
             <nav ui-nav className="navi clearfix">
               { this.renderYourRooms() }
-              { (this.props.activeRoomList.toArray().length > 0) ? this.renderActiveRooms(): null }
+              { (this.props.activeRoomList.toArray().length > 0) ? this.renderActiveRooms() : null }
             </nav>
           </div>
         </div>
@@ -129,8 +129,10 @@ Sidebar.defaultProps = {
   activeRoomList: Immutable.Map(),
   activeRoomsLoading: false,
   scrollToRoomName: null,
-  resetScrollToRoomName: () => {},
-  moreActiveRooms: () => {}
+  resetScrollToRoomName: () => {
+  },
+  moreActiveRooms: () => {
+  }
 };
 
 function mapStateToProps(state) {
@@ -142,6 +144,7 @@ function mapStateToProps(state) {
     roomList: getAllRooms(state),
     activeRoomList: getAllActiveRooms(state),
     activeRoomsLoading: getMoreActiveRoomsLoading(state),
+    isActiveRoomsCompleted: isActiveRoomsComplete(state),
     scrollToRoomName: getScrollToRoomName(state)
   };
 }

--- a/web/sidebar/Sidebar.jsx
+++ b/web/sidebar/Sidebar.jsx
@@ -9,7 +9,7 @@ import SidebarRoomRoom from './SidebarRoom';
 import { SidebarActiveRoom } from './SidebarActiveRoom';
 
 import { scrollToRoomNameReset } from '../redux/actions/scroll-actions';
-import { handleMoreActiveRooms } from '../redux/actions/active-rooms-actions';
+import { handleMoreActiveRooms, handleResetActiveRooms } from '../redux/actions/active-rooms-actions';
 
 import { getSidebarOpen, getScrollToRoomName, getMoreActiveRoomsLoading, isActiveRoomsComplete } from '../redux/selectors/ui-selectors';
 import { getAllRooms, getCurrentRoom, getCurrentRoomStyles } from '../redux/selectors/rooms-selectors';
@@ -75,15 +75,29 @@ class Sidebar extends Component {
     );
   }
 
+  renderCollapseButton() {
+    const styles = {
+      float: 'right',
+      fontSize: '1.1em'
+    };
+
+    return (
+      <span style={styles}>
+        <i className="fa fa-compress hoverable" onClick={ this.props.resetActiveRooms }></i>
+      </span>
+    );
+  }
+
   renderActiveRooms() {
     const sidebarColor = this.props.room.getIn(['styles', 'sidebarTextColor']);
     const activeRoomsStyles = { color: sidebarColor };
     const { isActiveRoomsCompleted } = this.props;
-    
+
     return (
-      <ul id="roomlist" className="nav">
+      <ul id="roomlist" className="nav" style={{ marginBottom: '10px' }}>
         <li key="active-rooms" className="hidden-folded padder m-t m-b-sm text-muted text-xs">
           <span style={activeRoomsStyles}>Active Rooms</span>
+          {(this.props.activeRoomList.toArray().length > 5) ? this.renderCollapseButton() : null}
         </li>
         {
           this.getOrderedActiveRooms().map((room) => {
@@ -160,6 +174,9 @@ function mapDispatchToProps(dispatch) {
     },
     moreActiveRooms() {
       dispatch(handleMoreActiveRooms());
+    },
+    resetActiveRooms() {
+      dispatch(handleResetActiveRooms());
     }
   };
 }

--- a/web/sidebar/Sidebar.jsx
+++ b/web/sidebar/Sidebar.jsx
@@ -9,7 +9,9 @@ import SidebarRoomRoom from './SidebarRoom';
 import { SidebarActiveRoom } from './SidebarActiveRoom';
 
 import { scrollToRoomNameReset } from '../redux/actions/scroll-actions';
-import { getSidebarOpen, getScrollToRoomName } from '../redux/selectors/ui-selectors';
+import { loadMoreActiveRooms } from '../redux/actions/active-rooms-actions';
+
+import { getSidebarOpen, getScrollToRoomName, getMoreActiveRoomsLoading } from '../redux/selectors/ui-selectors';
 import { getAllRooms, getCurrentRoom, getCurrentRoomStyles } from '../redux/selectors/rooms-selectors';
 import { getAllActiveRooms } from '../redux/selectors/active-rooms-selector';
 
@@ -48,10 +50,31 @@ class Sidebar extends Component {
     );
   }
 
+  renderLoadingIndicator() {
+    const indicatorStyles = { fontSize: "0.5em", margin: "5px 60px" };
+    return (
+      <div style={indicatorStyles}>
+        <i className="fa fa-circle-o-notch fa-spin fa-3x fa-fw"></i>
+        <span className="sr-only">Loading...</span>
+      </div>
+    );
+  }
+
+  renderMoreActiveRoomsButton() {
+    const { activeRoomsLoading } =  this.props;
+    const moreBtnStyles = { paddingLeft: "40px", margin: 0 };
+
+    return (
+      <li className="hidden-folded m-t m-b-sm text-muted" style={moreBtnStyles} onClick={this.props.moreActiveRooms}>
+        {(activeRoomsLoading) ? this.renderLoadingIndicator() : <a><b>+ more</b></a>}
+      </li>
+    );
+  }
+
   renderActiveRooms() {
     const sidebarColor = this.props.room.getIn(['styles', 'sidebarTextColor']);
     const activeRoomsStyles = { color: sidebarColor };
-    const moreBtnStyles = { paddingLeft: "40px", margin: 0 }
+
 
     return (
         <ul id="roomlist" className="nav">
@@ -68,9 +91,8 @@ class Sidebar extends Component {
               );
             })
           }
-          <li className="hidden-folded m-t m-b-sm text-muted" style={moreBtnStyles}>
-            <a><b>+ more</b></a>
-          </li>
+          {(this.props.activeRoomList.toArray().length > 4) ? this.renderMoreActiveRoomsButton() : null}
+
         </ul>
     );
   }
@@ -88,8 +110,8 @@ class Sidebar extends Component {
         <div className="aside-wrap">
           <div className="navi-wrap" ref="roomList">
             <nav ui-nav className="navi clearfix">
-              {this.renderYourRooms()}
-              {this.renderActiveRooms()}
+              { this.renderYourRooms() }
+              { (this.props.activeRoomList.toArray().length > 0) ? this.renderActiveRooms(): null }
             </nav>
           </div>
         </div>
@@ -104,8 +126,11 @@ Sidebar.defaultProps = {
   room: Immutable.Map(),
   roomName: null,
   roomList: Immutable.Map(),
+  activeRoomList: Immutable.Map(),
+  activeRoomsLoading: false,
   scrollToRoomName: null,
-  resetScrollToRoomName: () => {}
+  resetScrollToRoomName: () => {},
+  moreActiveRooms: () => {}
 };
 
 function mapStateToProps(state) {
@@ -116,6 +141,7 @@ function mapStateToProps(state) {
     roomName: state.get('currentRoom'),
     roomList: getAllRooms(state),
     activeRoomList: getAllActiveRooms(state),
+    activeRoomsLoading: getMoreActiveRoomsLoading(state),
     scrollToRoomName: getScrollToRoomName(state)
   };
 }
@@ -124,6 +150,9 @@ function mapDispatchToProps(dispatch) {
   return {
     resetScrollToRoomName() {
       dispatch(scrollToRoomNameReset());
+    },
+    moreActiveRooms() {
+      dispatch(loadMoreActiveRooms());
     }
   };
 }

--- a/web/sidebar/Sidebar.jsx
+++ b/web/sidebar/Sidebar.jsx
@@ -79,7 +79,7 @@ class Sidebar extends Component {
     const sidebarColor = this.props.room.getIn(['styles', 'sidebarTextColor']);
     const activeRoomsStyles = { color: sidebarColor };
     const { isActiveRoomsCompleted } = this.props;
-
+    console.log("isactiveRoomsCompleted: ", isActiveRoomsCompleted);
     return (
       <ul id="roomlist" className="nav">
         <li key="active-rooms" className="hidden-folded padder m-t m-b-sm text-muted text-xs">

--- a/web/sidebar/Sidebar.jsx
+++ b/web/sidebar/Sidebar.jsx
@@ -79,7 +79,7 @@ class Sidebar extends Component {
     const sidebarColor = this.props.room.getIn(['styles', 'sidebarTextColor']);
     const activeRoomsStyles = { color: sidebarColor };
     const { isActiveRoomsCompleted } = this.props;
-    console.log("isactiveRoomsCompleted: ", isActiveRoomsCompleted);
+    
     return (
       <ul id="roomlist" className="nav">
         <li key="active-rooms" className="hidden-folded padder m-t m-b-sm text-muted text-xs">

--- a/web/sidebar/Sidebar.jsx
+++ b/web/sidebar/Sidebar.jsx
@@ -9,7 +9,7 @@ import SidebarRoomRoom from './SidebarRoom';
 import { SidebarActiveRoom } from './SidebarActiveRoom';
 
 import { scrollToRoomNameReset } from '../redux/actions/scroll-actions';
-import { loadMoreActiveRooms } from '../redux/actions/active-rooms-actions';
+import { handleMoreActiveRooms } from '../redux/actions/active-rooms-actions';
 
 import { getSidebarOpen, getScrollToRoomName, getMoreActiveRoomsLoading, isActiveRoomsComplete } from '../redux/selectors/ui-selectors';
 import { getAllRooms, getCurrentRoom, getCurrentRoomStyles } from '../redux/selectors/rooms-selectors';
@@ -159,7 +159,7 @@ function mapDispatchToProps(dispatch) {
       dispatch(scrollToRoomNameReset());
     },
     moreActiveRooms() {
-      dispatch(loadMoreActiveRooms());
+      dispatch(handleMoreActiveRooms());
     }
   };
 }

--- a/web/sidebar/Sidebar.jsx
+++ b/web/sidebar/Sidebar.jsx
@@ -9,7 +9,7 @@ import SidebarRoomRoom from './SidebarRoom';
 import { SidebarActiveRoom } from './SidebarActiveRoom';
 
 import { scrollToRoomNameReset } from '../redux/actions/scroll-actions';
-import { handleMoreActiveRooms, handleResetActiveRooms } from '../redux/actions/active-rooms-actions';
+import { handleMoreActiveRooms, resetActiveRoomsList } from '../redux/actions/active-rooms-actions';
 
 import { getSidebarOpen, getScrollToRoomName, getMoreActiveRoomsLoading, isActiveRoomsComplete } from '../redux/selectors/ui-selectors';
 import { getAllRooms, getCurrentRoom, getCurrentRoomStyles } from '../redux/selectors/rooms-selectors';
@@ -176,7 +176,7 @@ function mapDispatchToProps(dispatch) {
       dispatch(handleMoreActiveRooms());
     },
     resetActiveRooms() {
-      dispatch(handleResetActiveRooms());
+      dispatch(resetActiveRoomsList());
     }
   };
 }

--- a/web/sidebar/SidebarActiveRoom.jsx
+++ b/web/sidebar/SidebarActiveRoom.jsx
@@ -1,38 +1,34 @@
-import React, { Component } from 'react';
-import Immutable from 'immutable';
+import React from 'react';
 
 import SidebarRoomName from './SidebarRoomName';
 import SidebarRoomAvatar from './SidebarRoomAvatar';
 import SidebarRoomSelect from './SidebarRoomSelect';
 
 export const SidebarActiveRoom = (props) => {
+  const { styles, room } = props;
 
-    const { styles, room } = props;
-
-    const renderActiveUsers = () => {
-
-        const activeUsersStyles = { backgroundColor: '#B73030', color: '#F8DCDC' };
-
-        return (
-            <div className="unread-count-room pull-right">
-                <b className="unreadcount label bg-info pull-right" style={activeUsersStyles}>{room.get('activeUsers')}</b>
-            </div>
-        );
-    };
-
-    const joinRoom = () => {
-        const url = `${window.location.origin}/r/${room.get('name')}`;
-        window.location.href = url;
-    };
+  const renderActiveUsers = () => {
+    const activeUsersStyles = { backgroundColor: '#B73030', color: '#F8DCDC' };
 
     return (
+      <div className="unread-count-room pull-right">
+        <b className="unreadcount label bg-info pull-right" style={activeUsersStyles}>{room.get('activeUsers')}</b>
+      </div>
+    );
+  };
 
-        <li className="roomlistentry" onClick={joinRoom} title="Active Users">
-            <SidebarRoomSelect styles={styles} active={false}>
-                <SidebarRoomAvatar room={room}/>
-                <SidebarRoomName room={room} styles={styles}/>
-                {renderActiveUsers()}
-            </SidebarRoomSelect>
-        </li>
-    )
-}
+  const joinRoom = () => {
+    const url = `${window.location.origin}/r/${room.get('name')}`;
+    window.location.href = url;
+  };
+
+  return (
+    <li className="roomlistentry" onClick={joinRoom} title="Active Users">
+      <SidebarRoomSelect styles={styles} active={false}>
+        <SidebarRoomAvatar room={room}/>
+        <SidebarRoomName room={room} styles={styles}/>
+        {renderActiveUsers()}
+      </SidebarRoomSelect>
+    </li>
+  );
+};

--- a/web/sidebar/SidebarActiveRoom.jsx
+++ b/web/sidebar/SidebarActiveRoom.jsx
@@ -1,0 +1,38 @@
+import React, { Component } from 'react';
+import Immutable from 'immutable';
+
+import SidebarRoomName from './SidebarRoomName';
+import SidebarRoomAvatar from './SidebarRoomAvatar';
+import SidebarRoomSelect from './SidebarRoomSelect';
+
+export const SidebarActiveRoom = (props) => {
+
+    const { styles, room } = props;
+
+    const renderActiveUsers = () => {
+
+        const activeUsersStyles = { backgroundColor: '#B73030', color: '#F8DCDC' };
+
+        return (
+            <div className="unread-count-room pull-right">
+                <b className="unreadcount label bg-info pull-right" style={activeUsersStyles}>{room.get('activeUsers')}</b>
+            </div>
+        );
+    };
+
+    const joinRoom = () => {
+        const url = `${window.location.origin}/r/${room.get('name')}`;
+        window.location.href = url;
+    };
+
+    return (
+
+        <li className="roomlistentry" onClick={joinRoom} title="Active Users">
+            <SidebarRoomSelect styles={styles} active={false}>
+                <SidebarRoomAvatar room={room}/>
+                <SidebarRoomName room={room} styles={styles}/>
+                {renderActiveUsers()}
+            </SidebarRoomSelect>
+        </li>
+    )
+}

--- a/web/sidebar/SidebarRoomName.jsx
+++ b/web/sidebar/SidebarRoomName.jsx
@@ -10,7 +10,7 @@ export default class SidebarRoomName extends Component {
     if (!room.get('isPrivate')) {
       return '#';
     }
-    return <SidebarRoomPrivateIcon styles={styles} />
+    return <SidebarRoomPrivateIcon styles={styles} />;
   }
 
   render() {

--- a/web/sidebar/SidebarRoomName.jsx
+++ b/web/sidebar/SidebarRoomName.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import Immutable from 'immutable';
 
-import SidebarRoomPrivateIcon from './SidebarRoomPrivateIcon'
+import SidebarRoomPrivateIcon from './SidebarRoomPrivateIcon';
 
 export default class SidebarRoomName extends Component {
   renderLockOrHash() {

--- a/web/sidebar/SidebarRoomUnreadCount.jsx
+++ b/web/sidebar/SidebarRoomUnreadCount.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux'
+import { connect } from 'react-redux';
 import Immutable from 'immutable';
 
 import { makeGetLastSeenTimeForRoom } from '../redux/selectors/last-seen-selectors';


### PR DESCRIPTION
### Active rooms - #3 

Added a list to the sidebar which displays the most active rooms. The "activeness" is defined by the number of users that posted in the last month. I thought that would be better than currently active users, since people are looking for rooms that are in general more active instead of rooms they could chat right now. If you think that is not a good criteria it is just a matter of changing the sql statements. 

Here is the SQL statement, I changed it a bit since I posted it in the issue.

```
SELECT id, name, displayName, iconUrl, activeUsers, rank
FROM (
	SELECT cr.id AS id, cr.name AS name, cr.displayname AS displayName, cr.iconurl AS iconUrl, COUNT(DISTINCT user_id) AS activeUsers, RANK() OVER (ORDER BY COUNT(DISTINCT user_id) DESC, name) as rank 
	FROM chatroom cr
	LEFT JOIN message m on cr.id = m.room_id
	WHERE m.createdate > (current_timestamp - interval '30 days')
	GROUP BY cr.id, cr.name, cr.displayname, cr.iconurl 
	ORDER BY activeUsers DESC
) AS ranked
WHERE name <> 'breakerapp' AND id NOT IN (
	SELECT room_id 
	FROM userroom
	WHERE user_id = :id
)
LIMIT :limit 
OFFSET :offset;
```

LIMIT, OFFSET and the userId are dynamically set. If the user is logged in the list doesn't include rooms the user has already joined. 

### How it looks
![sidebar](https://cloud.githubusercontent.com/assets/6655009/16007499/235dacd2-3173-11e6-8e91-1cd797c73ed3.png)

Critique is welcome and please test it with a bigger data set I just played around with one user. If I should reduce the pull request into 1 or 2 (client/server) commits please let me know.