### PR TITLE
Fixes for active rooms

### DIFF
--- a/app/com/larvalabs/redditchat/dataobj/JsonActiveRoomsUtil.java
+++ b/app/com/larvalabs/redditchat/dataobj/JsonActiveRoomsUtil.java
@@ -23,7 +23,7 @@ public class JsonActiveRoomsUtil {
         List<JsonActiveChatRoom> additionalRooms = new ArrayList<>();
 
         while (activeRoomsState.size() < amount &&
-                (additionalRooms = ActiveRoomsService.findMostActiveRooms(amount - activeRoomsState.size(), offset-1, user.getId())).size() > 0) {
+                (additionalRooms = ActiveRoomsService.findMostActiveRooms(30, offset-1, user.getId())).size() > 0) {
 
             activeRoomsState = updateRoomsToState(activeRoomsState, additionalRooms, joinedUserRoom, offset, amount);
             offset = getLastRank(offset, additionalRooms);


### PR DESCRIPTION
1) By changing the query I removed rooms that only have posts from the bot
2) It is slow for @megamattron because the subsequent queries to fill the first five entries only read the amount of rooms that where missing, but since you are joined a couple of hundred rooms, I think the initial state generation made a lot of queries requesting only one room. Now it always loads 30, this may be a lot better for you, but it overloads for users which are joined only a handful of rooms. I don't know what's the best amount, I guess to figure out the most efficient limit, we need some data about how many rooms an average user is in.

**Maybe changing the 1 month period into 2 weeks would be better, since sandersforpresident is first without a message in two weeks.**